### PR TITLE
fix polyfill

### DIFF
--- a/app.js
+++ b/app.js
@@ -271,10 +271,10 @@ app.get('/', function(req, res, next) {
 		case '360.vizor.io':
 		case '360.vizor.lol':
 			return threesixtyController.index(req, res, next)
-		case 'patches.vizor.io':
-			return homeController.index(req, res, next)
-		default:
+		case 'vizor.io':
 			return vizor2TeaserController.index(req, res, next)
+		default:
+			return homeController.index(req, res, next)
 	}
 })
 

--- a/browser/plugins/three_webgl_renderer.plugin.js
+++ b/browser/plugins/three_webgl_renderer.plugin.js
@@ -151,7 +151,7 @@
 			updateCamera(E2.app.worldEditor.getCamera(), s)
 
 		this.renderer.setPixelRatio(s.devicePixelRatio)
-		this.adapter.effect.setSize(s.width, s.height)
+		this.adapter.effect.setSize(s.width, s.height, false)
 	}
 
 	ThreeWebGLRendererPlugin.prototype.state_changed = function(ui) {

--- a/browser/scripts/embed.js
+++ b/browser/scripts/embed.js
@@ -54,7 +54,10 @@
 
 
 	window.addEventListener('orientationchange', function() {
-		iframeWindow.postMessage({ orientation: window.orientation }, '*')
+		iframeWindow.postMessage({
+			type: 'orientationchange',
+			orientation: window.orientation
+		}, '*')
 		return true
     }, false)
 
@@ -74,7 +77,7 @@
 
 	document.write('<iframe id="'+iframeId+'" src="'+url+
 		'" width="'+ iframeWidth +'" height="' + iframeHeight +
-		'" frameborder="0" style="box-sizing:border-box;" allowfullscreen></iframe>')
+		'" frameborder="0" style="box-sizing:border-box;" allowfullscreen allowvr></iframe>')
 
 	iframeElement = document.getElementById(iframeId)
 	iframeWindow = document.getElementById(iframeId).contentWindow
@@ -88,20 +91,23 @@
 	}, true)
 	window.addEventListener('resize', resizeIframe)
 	window.addEventListener('devicemotion', function(deviceMotion) {
+		var evtData = {
+			accelerationIncludingGravity: {
+				x: deviceMotion.accelerationIncludingGravity.x,
+				y: deviceMotion.accelerationIncludingGravity.y,
+				z: deviceMotion.accelerationIncludingGravity.z
+			},
+			rotationRate: {
+				alpha: deviceMotion.rotationRate.alpha,
+				beta: deviceMotion.rotationRate.beta,
+				gamma: deviceMotion.rotationRate.gamma
+			},
+			timeStamp: deviceMotion.timeStamp
+		}
 		iframeWindow.postMessage({
-			devicemotion: {
-				accelerationIncludingGravity: {
-					x: deviceMotion.accelerationIncludingGravity.x,
-					y: deviceMotion.accelerationIncludingGravity.y,
-					z: deviceMotion.accelerationIncludingGravity.z
-				},
-				rotationRate: {
-					alpha: deviceMotion.rotationRate.alpha,
-					beta: deviceMotion.rotationRate.beta,
-					gamma: deviceMotion.rotationRate.gamma
-				},
-				timeStamp: deviceMotion.timeStamp
-			}
+			devicemotion: evtData,
+			deviceMotionEvent: evtData,
+			type: 'devicemotion'
 		}, '*')
 	}, false)
 

--- a/browser/scripts/player.js
+++ b/browser/scripts/player.js
@@ -340,7 +340,7 @@ function CreatePlayer(cb) {
 
 	// Shared gl context for three
 	var gl_attributes = {
-		alpha: true,
+		alpha: false,
 		depth: true,
 		stencil: true,
 		antialias: true,

--- a/browser/scripts/ui/playerUI.js
+++ b/browser/scripts/ui/playerUI.js
@@ -22,8 +22,8 @@ var VizorPlayerUI = function() {
 		controlsDisplayed	: 'controlsDisplayed',
 		controlsHidden		: 'controlsHidden',
 
-		vrInstructionsShown : 'VRInstructionsShown',
-		vrInstructionsHidden: 'VRInstructionsHidden',
+		vrInstructionsShown : 'vrinstructionsshown',
+		vrInstructionsHidden: 'vrinstructionshidden',
 		loadingProgress		: 'progress',
 
 		playerStateChanged	: 'player:stateChanged',
@@ -192,7 +192,7 @@ var VizorPlayerUI = function() {
 		E2.core.on('assetsLoaded', completeLoading)
 
 		// provisions for chrome/android
-		$body
+		$(window)
 			.on(events.vrInstructionsShown, function () {
 				$canvas.hide()
 			})
@@ -337,7 +337,7 @@ var VizorPlayerUI = function() {
 				that.queueHeaderFadeOut()
 			})
 
-		$body
+		$(window)
 			.on(events.vrInstructionsShown, function () {
 				$header.hide()
 				that.fadingIn = that.fadingOut = false

--- a/browser/scripts/webVRAdapter.js
+++ b/browser/scripts/webVRAdapter.js
@@ -46,8 +46,7 @@ VizorWebVRAdapter.prototype.initialise = function(domElement, renderer) {
 	this.configure()
 
 	this.proxyOrientationChange = true
-	this.proxyDeviceMotion = (typeof VizorUI !== 'undefined') 
-		&& VizorUI.isMobile.iOS()
+	this.proxyDeviceMotion = this.isIOS
 
 	if (document.body.classList)
 		document.body.classList.toggle('hasHMD', this.haveVRDevices)
@@ -71,9 +70,13 @@ VizorWebVRAdapter.events = Object.freeze({
 	targetResized: 			'targetsizechanged'
 })
 
-VizorWebVRAdapter.prototype.canInitiateCameraMove = function(e) {
+/**
+ * @param ev MouseEvent|TouchEvent|KeyboardEvent
+ * @returns boolean
+ */
+VizorWebVRAdapter.prototype.canInitiateCameraMove = function(ev) {
 	if (E2 && E2.app && E2.app.canInitiateCameraMove)
-		return E2.app.canInitiateCameraMove(e)
+		return E2.app.canInitiateCameraMove(ev)
 
 	// default
 	return true
@@ -97,6 +100,34 @@ VizorWebVRAdapter.prototype.configure = function() {
 	w.TOUCH_PANNER_DISABLED	= false
 	w.MOUSE_KEYBOARD_CONTROLS_DISABLED	= false
 
+	function patchDisplay(display) {
+		if (display._vizorPatched)
+			return
+
+		function patchPanner(panner) {
+			panner.shouldRotateStart = that.canInitiateCameraMove.bind(that)
+		}
+		switch (display.displayName) {
+			case 'Mouse and Keyboard VRDisplay (webvr-polyfill)':
+				patchPanner(display)
+				display.getDimensions = that.getDomElementDimensions.bind(that);
+				break;
+			case 'Cardboard VRDisplay (webvr-polyfill)':
+				patchPanner(display.poseSensor_.touchPanner)
+				display.getDimensions = function() {
+					if (this.isPresenting)
+						return this.prototype.getDimensions.call(this)
+					// else
+					return that.getDomElementDimensions()
+				}.bind(display)
+				break;
+			default:
+				// nothing to patch
+		}
+		display._vizorPatched = true
+	}
+	
+
 	navigator.getVRDisplays()
 	.then(function(displays){
 		if (!displays.length) {
@@ -106,25 +137,9 @@ VizorWebVRAdapter.prototype.configure = function() {
 		}
 
 		displays.forEach(function(display) {
+			patchDisplay(display)
 			if (display.capabilities.canPresent)
 				that.haveVRDevices = true
-
-			if (display._vizorPatched)
-				return
-
-			if (typeof display.getManualPannerRef === 'function') {
-				var panner = display.getManualPannerRef()
-				if (!(panner && panner.canInitiateRotation))
-					return
-				panner.canInitiateRotation = function(e){
-					return that.canInitiateCameraMove(e)
-				}
-			} else {
-				console.warn('no display.getManualPannerRef found', display)
-			}
-
-			display._vizorPatched = true
-
 			// note, if display.wrapForFullscreen (removeFullscreenWrapper) is taken out
 			// then the cardboard selector won't show on Android because it would fullscreen the canvas, not its parent element
 		})
@@ -147,16 +162,12 @@ VizorWebVRAdapter.prototype.configure = function() {
 	})
 
 	var r = E2.core.renderer
-	if (typeof r.setSizeNoResize === 'undefined') {
-		console.error('please patch THREE.WebGLRenderer to include a setSizeNoResize method.')
-	}
-	else {
-		r.setSize = function (width, height) {
-			// debug
-			// console.error('renderer.setSize called instead of setSizeNoResize')
-			this.setSizeNoResize(width, height)
-		}.bind(r)
-	}
+	r._setSize = r.setSize
+	r.setSize = function (width, height) {
+		this._setSize(width, height, false)	// ex .setSizeNoResize()
+	}.bind(r)
+
+	window._WA = this
 }
 
 // patches the web vr manager so that requestFullscreen fullscreens our container
@@ -279,10 +290,9 @@ VizorWebVRAdapter.prototype.onBrowserResize = function() {
 		that.resizeToTarget()
 	}
 
-	if (!this.iOS && this.hmd && !this.hmd.isPolyfilled)
-		doResize()
-	else
-		this._scheduleResize(doResize, timeout)
+	doResize()
+	if (this.iOS || !this.hmd || this.hmd.isPolyfilled)
+    this._scheduleResize(doResize, timeout)
 }
 
 VizorWebVRAdapter.prototype.isElementFullScreen = function() {
@@ -370,43 +380,35 @@ VizorWebVRAdapter.prototype.setTargetSize = function(width, height, devicePixelR
 }
 
 VizorWebVRAdapter.prototype.getTargetSize = function() {
-	var manager = this._manager
 	var hmd = this.hmd
 	var isPresenting = hmd && hmd.isPresenting
 
 	var size = {
 		width: -1,
 		height: -1,
-		devicePixelRatio: 0
+		devicePixelRatio: 0,
+		isPresenting: isPresenting
 	}
 
 	var domSize = this.getDomElementDimensions()
 
+	size.devicePixelRatio = window.devicePixelRatio
 	if (isPresenting) {
-		var leftEye  = hmd.getEyeParameters("left")
-		var rightEye = hmd.getEyeParameters("right")
-
-		var dpr = window.devicePixelRatio
-
-		size.width  = leftEye.renderWidth + rightEye.renderWidth
-		size.height = leftEye.renderHeight // assume they're the same
-		size.width /= dpr
-		size.height /= dpr
-		size.devicePixelRatio = dpr
+		// assume presenting in landscape (eyes are horizontal)
+		size.width = Math.max(screen.width, screen.height)
+		size.height = Math.min(screen.width, screen.height)
 	}
 	else {
 		size.width  = domSize.width
 		size.height = domSize.height
-		size.devicePixelRatio = window.devicePixelRatio
 	}
-
-	size.isPresenting = !!isPresenting
 
 	return size
 }
 
 // event handling
 VizorWebVRAdapter.prototype.onMessageReceived = function(e) {
+	return;
 	if (!e.data)
 		return
 
@@ -507,7 +509,7 @@ VizorWebVRAdapter.prototype.amendVRManagerInstructions = function() {
 	s.display = 'block'
 
 	o.style.height = '100%'
-o.insertBefore(svg, o.firstChild)
+	o.insertBefore(svg, o.firstChild)
 
 
 	r.text.innerHTML = r.text.innerHTML.replace("Cardboard viewer", "VR viewer")
@@ -687,10 +689,6 @@ VizorWebVRAdapter.isNativeWebVRAvailable = function() {
 
 VizorWebVRAdapter.prototype.isNativeWebVRAvailable = VizorWebVRAdapter.isNativeWebVRAvailable
 
-VizorWebVRAdapter.prototype.getEyeParameters = function(eye) {
-	return this.hmd.getEyeParameters(eye)
-}
 
 if (typeof module !== 'undefined')
 	module.exports = VizorWebVRAdapter
-

--- a/browser/scripts/webVRAdapter.js
+++ b/browser/scripts/webVRAdapter.js
@@ -163,8 +163,8 @@ VizorWebVRAdapter.prototype.configure = function() {
 
 	var r = E2.core.renderer
 	r._setSize = r.setSize
-	r.setSize = function (width, height) {
-		this._setSize(width, height, false)	// ex .setSizeNoResize()
+	r.setSize = function (width, height) {	// becomes part of RAF loop
+		this._setSize(width, height, false)		// ex .setSizeNoResize(); never update element
 	}.bind(r)
 
 	window._WA = this

--- a/browser/vendor/three/VREffect.js
+++ b/browser/vendor/three/VREffect.js
@@ -82,8 +82,7 @@ THREE.VREffect = function ( renderer, onError ) {
 	};
 
 	this.setSize = function ( width, height, updateStyle ) {
-    renderer.setSize( width, height );
-
+    renderer.setSize( width, height, updateStyle );
 	};
 
 	// VR presentation

--- a/browser/vendor/three/three.js
+++ b/browser/vendor/three/three.js
@@ -21257,10 +21257,12 @@
 			_width = width;
 			_height = height;
 
-			_canvas.width = width * _pixelRatio;
-			_canvas.height = height * _pixelRatio;
 
 			if ( updateStyle !== false ) {
+				
+				// gm^vizor.io; moved down from before the block
+				_canvas.width = width * _pixelRatio;
+				_canvas.height = height * _pixelRatio;
 
 				_canvas.style.width = width + 'px';
 				_canvas.style.height = height + 'px';
@@ -21269,14 +21271,6 @@
 
 			this.setViewport( 0, 0, width, height );
 
-		};
-
-
-		this.setSizeNoResize = function(width, height) {
-			// gm^vizor.io
-			_width = width;
-			_height = height;
-			this.setViewport( 0, 0, width, height );
 		};
 
 

--- a/views/graph/show.handlebars
+++ b/views/graph/show.handlebars
@@ -62,11 +62,11 @@
 </header>
 
 <div id="playerWrap" style="background: #000 url('{{{previewImage}}}') center center no-repeat; background-size: cover;">
-    <div id="beforeLoadingStage" class="stage"></div>
+    <div id="beforeLoadingStage" class="stage front"></div>
     <div id="loadingStage" class="stage"></div>
     <div id="readyStage" class="stage"></div>
     <div id="errorStage" class="stage"></div>
-    <div id="playingStage" class="stage front">
+    <div id="playingStage" class="stage">
         {{> playerCanvas width="100%" height="100%" graphSrc=graphMinUrl autoplay=autoplay }}
     </div>
 </div>

--- a/views/server/partials/home/homeHero.handlebars
+++ b/views/server/partials/home/homeHero.handlebars
@@ -4,8 +4,8 @@
 	</div>
 
     <div id="herotext" class="noselect">
-        <h1 style="line-height: 1.5">Create WebVR experiences <br class="nodesktop notablet" />
-            without writing code</h1>
+		<h1 style="line-height: 1.5">Create WebVR experiences
+			<br class="nodesktop notablet" />&nbsp;without writing code</h1>
         <div class='desktoponly'>
             <a href="/matt/earth-with-clouds-v2/edit/" class="btn cta nomobile">Edit this project</a>
             <a href="/edit" class="btn cta">New blank project</a>


### PR DESCRIPTION
note PR base branch

further fixes:
blackscreen in Hungry Spirits (render-to-texture plugin and Three messing up the canvas)

tested in:

- desktop: Safari, Firefox, Chrome
- mobile: iOS iPhone 6S, iPhone SE, Android Samsung S6
- embed: all of the above
- for orientation: landscape and portrait on standalone and embedded
- for devicemotion: all mobile, standalone and embedded

needs further testing in MS Edge

notes:

- the polyfill now implements its own method to receive messages in iframe, which seems to be missing orientationchange processing. Switching orientation in an iframe didn't work for me. Additionally, with the latest version of Android, devicemotion and orientation events seem to need proxying just as on iOS.
- restored event on VR instructions showing and hiding
- restored "canInitiateRotation" method as "shouldRotateStart" in both MouseKeyboardDisplay and TouchPanner
- adjusted iOS minimum time delta constant (accelerometer) that previously flooded the console
- this may break backwards compatibility with some experiences (though those wouldn't work in new browsers anyway)

known issue: in Safari 11 on macOS High Sierra, links in the Share dialogue may not work. Should this happen, resizing the window with the panel onscreen restores the correct behaviour (‽).

