### PR TITLE
mock window.dispatchEvent to fix tests

### DIFF
--- a/browser/test/integration/helpers.js
+++ b/browser/test/integration/helpers.js
@@ -105,6 +105,7 @@ exports.reset = function() {
 	global.window.screen = {width: 1280, height: 720}
 
 	global.addEventListener = function() {}
+	global.dispatchEvent = function() {}
 	global.removeEventListener = function() {}
 	global.location = {
 		pathname: 'test/test'


### PR DESCRIPTION
```
bash-3.2$ mocha browser/test/integration/init-revolver.js


  Initialisation together with if statements
reset 1 1 1
reset 1 1 1
THREE.Object3D.add: object not an instance of THREE.Object3D. undefined
THREE.Object3D.add: object not an instance of THREE.Object3D. undefined
    ✓ inits the correct number (269ms)


  1 passing (443ms)


```