### PR TITLE
fix resolution in GearVR/Oculus browser

### DIFF
--- a/browser/scripts/webVRAdapter.js
+++ b/browser/scripts/webVRAdapter.js
@@ -392,15 +392,18 @@ VizorWebVRAdapter.prototype.getTargetSize = function() {
 
 	var domSize = this.getDomElementDimensions()
 
-	size.devicePixelRatio = window.devicePixelRatio
 	if (isPresenting) {
-		// assume presenting in landscape (eyes are horizontal)
-		size.width = Math.max(screen.width, screen.height)
-		size.height = Math.min(screen.width, screen.height)
+		// { renderWidth, renderHeight }
+		var left = hmd.getEyeParameters('left')
+		var right = hmd.getEyeParameters('right')
+		size.width = left.renderWidth + right.renderWidth
+		size.height = Math.min(left.renderHeight, right.renderHeight)
+		size.devicePixelRatio = 1
 	}
 	else {
 		size.width  = domSize.width
 		size.height = domSize.height
+		size.devicePixelRatio = window.devicePixelRatio
 	}
 
 	return size

--- a/browser/test/functional/support/action/openEditor.js
+++ b/browser/test/functional/support/action/openEditor.js
@@ -24,11 +24,11 @@ module.exports = function (done) {
         .url(url)
 		.waitForExist('body.bEditor')
 		.waitForExist('div#canvases')
-		.waitForVisible('div.welcome', 5000)
+		.waitForVisible('.welcome', 5000)
 		.then(function(){
 			browser
-				.click('div.welcome button.close')
-				.waitForExist('div.welcome', null, true)
+				.click('.welcome button.close')
+				.waitForExist('.welcome', null, true)
 				.deleteCookie('vizor100')
 				.then(ff)
 		}, ff)

--- a/browser/test/functional/support/action/waitForEditor.js
+++ b/browser/test/functional/support/action/waitForEditor.js
@@ -23,11 +23,11 @@ module.exports = function (done) {
         .url(url)
 		.waitForExist('body.bEditor')
 		.waitForExist('div#canvases')
-		.waitForVisible('div.welcome', 5000)
+		.waitForVisible('.welcome', 5000)
 		.then(function(){
 			browser
 				.click('div.welcome button.close')
-				.waitForExist('div.welcome', null, true)
+				.waitForExist('.welcome', null, true)
 				.deleteCookie('vizor100')
 				.then(ff)
 		}, ff)


### PR DESCRIPTION
fix #2078 

background: `devicePixelRatio` when `isPresenting` is 1 and canvas sizing must be determined from the actual `renderWidth` and `renderHeight` parameters for each eye.

for the GearVR Samsung S6 `renderWidth` and `renderHeight` equal 1024, but the display is 2560x1440, so some upscaling is forced.

I experimented with calculating devicePixelRatio instead in order to achieve higher quality image, but got inconsistent results across the range VR/iOS/Android-cardboard.

tested on: 

- macOS: desktop (Safari), 
- iOS: magic window & polyfilled VR
- Android: magic window, polyfilled VR, GearVR/Oculus browser
