### PR TITLE
Hack OBJLoader to work with machinedrum/ocean-of-thought objs

### DIFF
--- a/browser/vendor/three/OBJLoader.js
+++ b/browser/vendor/three/OBJLoader.js
@@ -466,6 +466,11 @@ THREE.OBJLoader = ( function () {
 
 				} else if ( lineFirstChar === 'l' ) {
 
+					// TODO XXX FIXME HACK
+					// drop these like the old loader used to
+					// fixes Machinedrum - Ocean of Thought obj's
+					continue;
+
 					var lineParts = line.substring( 1 ).trim().split( " " );
 					var lineVertices = [], lineUVs = [];
 


### PR DESCRIPTION
This is a bug that slipped in the last release. When decimating objects in Blender, they are left with `l` lines in the .obj that are out of place, making the loader attempt to put two kinds of geometries in the same object. This works around that bug by simply ignoring the `l` lines altogether, like the previous version of the loader did.