### PR TITLE
Patches TOS&PP link changes

### DIFF
--- a/browser/help/introduction.html
+++ b/browser/help/introduction.html
@@ -107,7 +107,7 @@
 		<br>
 
 		<h3>Terms of Service & Privacy policy</h3>
-		<a href="https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing">Terms & Privacy</a>
+		<a href="https://site.vizor.io/patches-tos">Terms of Service</A> & <a href="https://site.vizor.io/patches-privacy-policy">Privacy</a>
 		
 
 	</div>

--- a/browser/help/introduction.html
+++ b/browser/help/introduction.html
@@ -103,7 +103,7 @@
 
 		<h3>Attributions</h3>
 		<br>
-		<a href="https://docs.google.com/document/d/1L87rs9baSoR4PfOZ2cY9BFp3Pb43y8cFvS93k1HLk60/edit?usp=sharing">Attributions</a>
+		<a href="https://site.vizor.io/patches-attribution">Attributions</a>
 		<br>
 
 		<h3>Terms of Service & Privacy policy</h3>

--- a/browser/scripts/threesixty.js
+++ b/browser/scripts/threesixty.js
@@ -459,7 +459,7 @@ E2.ui.ui360 = new function() {
 	
 	this.addTOSButton = function() {
 		var data = {
-			href: 'https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing',
+			href: 'https://site.vizor.io/patches-tos',
 			id: 'tosbutton',
 			text: 'Terms',
 			svgref : 'vr360-tos',

--- a/views/partials/account/signup.handlebars
+++ b/views/partials/account/signup.handlebars
@@ -39,5 +39,5 @@
 	<p>Creating a Patches account means you accept our
 		<a href="https://site.vizor.io/patches-tos" target="_blank" alt="Patches Terms of Use">Terms of Use</a>
 		and
-		<a href="https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing" target="_blank" alt="Privacy Policy">Privacy Policy</a>.
+		<a href="https://site.vizor.io/patches-privacy-policy" target="_blank" alt="Privacy Policy">Privacy Policy</a>.
 </div>

--- a/views/partials/account/signup.handlebars
+++ b/views/partials/account/signup.handlebars
@@ -37,7 +37,7 @@
 <div class="modal-footer">
 	<p>Already have an account? <a href="/login" id="signinModalLink" class="login" alt="Sign in">Sign in here</a>
 	<p>Creating a Patches account means you accept our
-		<a href="https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing" target="_blank" alt="Patches Terms of Use">Terms of Use</a>
+		<a href="https://site.vizor.io/patches-tos" target="_blank" alt="Patches Terms of Use">Terms of Use</a>
 		and
 		<a href="https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing" target="_blank" alt="Privacy Policy">Privacy Policy</a>.
 </div>

--- a/views/server/partials/home/_footer.handlebars
+++ b/views/server/partials/home/_footer.handlebars
@@ -34,7 +34,7 @@
         </a>
 
         <a class="googledocs legal" href="https://docs.google.com/document/d/1L87rs9baSoR4PfOZ2cY9BFp3Pb43y8cFvS93k1HLk60/edit?usp=sharing" target="_blank">Attribution</a>
-        <a class="googledocs legal terms" href="https://docs.google.com/document/d/172dWVz8bSEDxS_y2InXpqWhVvbM7w1Z9MSp1-Lw1rIc/edit?usp=sharing" target="_blank">Terms of Use</a>
+        <a class="googledocs legal terms" href="https://site.vizor.io/patches-tos" target="_blank">Terms of Use</a>
     </nav>
 
     <h6 id="brandBottom">

--- a/views/server/partials/home/_footer.handlebars
+++ b/views/server/partials/home/_footer.handlebars
@@ -33,8 +33,8 @@
             </svg>
         </a>
 
-        <a class="googledocs legal" href="https://site.vizor.io/patches-attribution" target="_blank">Attribution</a>
-        <a class="googledocs legal terms" href="https://site.vizor.io/patches-tos" target="_blank">Terms of Use</a>
+        <a class="Hubspot Attribution" href="https://site.vizor.io/patches-attribution" target="_blank">Attribution</a>
+        <a class="Hubspot Terms of Use" href="https://site.vizor.io/patches-tos" target="_blank">Terms of Use</a>
     </nav>
 
     <h6 id="brandBottom">

--- a/views/server/partials/home/_footer.handlebars
+++ b/views/server/partials/home/_footer.handlebars
@@ -33,7 +33,7 @@
             </svg>
         </a>
 
-        <a class="googledocs legal" href="https://docs.google.com/document/d/1L87rs9baSoR4PfOZ2cY9BFp3Pb43y8cFvS93k1HLk60/edit?usp=sharing" target="_blank">Attribution</a>
+        <a class="googledocs legal" href="https://site.vizor.io/patches-attribution" target="_blank">Attribution</a>
         <a class="googledocs legal terms" href="https://site.vizor.io/patches-tos" target="_blank">Terms of Use</a>
     </nav>
 


### PR DESCRIPTION
This changes all GoogleDocs links to HubSpot links for Terms of Service & Privacy Policy.